### PR TITLE
updates to make install possible

### DIFF
--- a/jaxbo/models.py
+++ b/jaxbo/models.py
@@ -1007,7 +1007,7 @@ class MultifidelityGP(GPmodel):
         return mu, std
     
     @partial(jit, static_argnums=(0,))
-    def posterior_covariance_L(self, x, xp **kwargs):
+    def posterior_covariance_L(self, x, xp, **kwargs):
         params = kwargs['params']
         batch = kwargs['batch']
         bounds = kwargs['bounds']

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ with io.open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'numpy',
     'scipy',
-    'jax>=0.1.55',
-    'jaxlib>=0.1.37',
+    'jax==0.2.19',
+    'jaxlib==0.1.70',
     'sklearn',
     'KDEpy',
     'pyDOE',


### PR DESCRIPTION
We were trying to  use JAX-BO for a project but it has two issues that made installation fail:
- there was a syntax error in one of the models
- the `index_update` function of JAX [was deprecated](https://jax.readthedocs.io/en/latest/jax.ops.html), so I required in `setup.py` an older version of `jax` and `jaxlib`. Long term should be better to update the code to make it work with the current version of JAX.